### PR TITLE
update multi-storage to append link to resume

### DIFF
--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -125,11 +125,10 @@ reference for Alice to `resume`.
 
 Danielle agrees to give Alice a personal reference, which Alice will link to
 in the reference section of `resume`. Alice gives Danielle [=read access=] to
-`resume` for context, and [=append access=] to a `recommendations` inbox.
-Danielle creates a recommendation on their [=resource server=] at
-`https://danielle.example/recommendation`. Danielle is the [=resource
-controller=] for that resource and gives it public [=read access=]. Danielle
-then notifies Alice's inbox about the recommendation.
+`resume` for context, and [=append access=] so that she can add a link to
+the recommendation that she creates and hosts on her own [=resource server=]
+at `https://danielle.example/recommendation`. Danielle is the
+[=resource controller=] for that resource and gives it public [=read access=]. 
 
 ### Append-only access ### {#basic-appendonly}
 
@@ -894,9 +893,9 @@ Her client's credential manager should see this and select
 the credential revealing the least amount of information needed to access
 the resource.
 
-### High Security Scenario ### {#uc-confidential} 
+### High Security Scenario ### {#uc-confidential}
 
-A service with very high security and confidentiality requirements must publish 
+A service with very high security and confidentiality requirements must publish
 resources without the URL for any resource leaking information about it's content.
 This service publishes all these resources using the Tor protocol, so that the location
 of the servers can remain secret.
@@ -904,7 +903,7 @@ All resources on this Solid server are named by the root container using
 a UUID naming scheme.
 
 <figure>
-<figcaption>Contents under 
+<figcaption>Contents under
 `https://ciadotgov4sjwlzihbbgxnqg3xiyrg7so2r2o3lt5wz5ypk4sxyjstad.onion/`</figcaption>
   <table class="data collections" align="left">
     <col>


### PR DESCRIPTION
This makes a slight adjustment to the multi-store use case to append to a single resource instead of a container, since this is in the basic resource access section (permissions for a single resource).