### PR TITLE
Add use case to block access to bad actors

### DIFF
--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1013,6 +1013,16 @@ Unfortunately, anyone can setup an identity provider, so Carol would
 like to be able to recognize credentials issued from trustworthy
 identity providers.
 
+### Block access to agents ### {#uc-blockagents}
+
+A nonpartisian group provides a public annotation service, and allows any
+[=authenticated agent=] to share fact-checked information.
+
+Unfortunately, there are bad actors that would like to expose misinformation
+and disinformation through the annotation service. The trusted moderators of
+the service would like to be able to block the bad actors from sharing content
+in the future.
+
 ## Validation ## {#uc-validation}
 
 Juan likes to manage his [=authorizations=] manually. Every

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1015,13 +1015,13 @@ identity providers.
 
 ### Block access to agents ### {#uc-blockagents}
 
-A nonpartisian group provides a public annotation service, and allows any
+A nonpartisan group provides a public annotation service, and allows any
 [=authenticated agent=] to share fact-checked information.
 
-Unfortunately, there are bad actors that would like to expose misinformation
-and disinformation through the annotation service. The trusted moderators of
-the service would like to be able to block the bad actors from sharing content
-in the future.
+Unfortunately, there are bad actors that seek to expose misinformation and
+disinformation through the annotation service. The trusted moderators of the
+service would like to be able to block bad actors from sharing content in the
+future.
 
 ## Validation ## {#uc-validation}
 


### PR DESCRIPTION
Some mentions about the notion to block bad actors:

* https://github.com/solid/authorization-panel/issues/111
* https://github.com/solid/authorization-panel/issues/115
* https://csarven.ca/linked-research-decentralised-web#addressing-social-implications
* https://dr.amy.gy/chapter3
* https://github.com/solid/authorization-panel/blob/master/proposals/TrustedAppsReplacement.md
* https://www.w3.org/2001/tag/doc/ethical-web-principles/#community (re initial Solid proposal to adopt Ethical Web Principles: https://lists.w3.org/Archives/Public/public-solid/2019Jun/0000.html )


This is a widely known issue to acknowledge. Plethora of examples and studies out there. Important in many areas: journalism, social web, scholarly communication..