### PR TITLE
Add use case for client to discover access privileges

### DIFF
--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -922,8 +922,8 @@ allowed to perform, the public, as well as any other group.
 For example, for user level permission, if the application is not granted
 [=write access=] on the resource that Guinan is currently editing, the UI can
 disable the "Save" button in the menu. Guinan also wants to know if the
-content they are updating is granted [=read access=] to the public -
-consequently, eg. if it can be liked, bookmarked, archived by everyone.
+public is granted [=read access=] on the content they are updating, and
+thus if it can be, for example, liked, bookmarked, archived by everyone.
 
 
 ## Privacy ## {#uc-privacy}

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -920,7 +920,7 @@ adapts its user interface by way of distinguishing between allowed
 application, to the public (everyone), or to a group.
 
 For example, for user level permission, if the application is not granted
-write access on the resource that Guinan is currently editing, the user
+[=write access=] on the resource that Guinan is currently editing, the user
 interface can disable the "Save" button in the menu. Guinan also wants to know
 if the public is granted [=read access=] on the content they are updating, and
 thus if it can be, for example, liked, bookmarked, archived by everyone.

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -914,7 +914,7 @@ that she can access.
 ### Application determining access privileges {#uc-client-determine-access-privileges}
 
 Guinan uses an application to author and publish documents. The application
-adapts its user interface by way of distinguishing between allowed
+adapts its user interface to distinguish between allowed
 (actionable) and disallowed features based on access information that the
 [=resource server=] reveals, for example, permissions that are granted to the
 application, to the public (everyone), or to a group.

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -911,18 +911,18 @@ write access. Alice grants *PerformChart* read only access to all the projects
 that she can access.
 
 
-### Application discovering access privileges {#uc-client-discover-access-privileges}
+### Application determining access privileges {#uc-client-determine-access-privileges}
 
 Guinan uses an application to author and publish documents. The application
-adapts its UI to the access privileges in order to distinguish between allowed
-(actionable) and disallowed features for different permission groups. The
-application can make use of information to assist Guinan based on what it is
-allowed to perform, the public, as well as any other group.
+adapts its user interface by way of distinguishing between allowed
+(actionable) and disallowed features based on access information that the
+[=resource server=] reveals, for example, permissions that are granted to the
+application, to the public (everyone), or to a group.
 
 For example, for user level permission, if the application is not granted
-[=write access=] on the resource that Guinan is currently editing, the UI can
-disable the "Save" button in the menu. Guinan also wants to know if the
-public is granted [=read access=] on the content they are updating, and
+write access on the resource that Guinan is currently editing, the user
+interface can disable the "Save" button in the menu. Guinan also wants to know
+if the public is granted [=read access=] on the content they are updating, and
 thus if it can be, for example, liked, bookmarked, archived by everyone.
 
 

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -911,6 +911,21 @@ write access. Alice grants *PerformChart* read only access to all the projects
 that she can access.
 
 
+### Application discovering access privileges {#uc-client-discover-access-privileges}
+
+Guinan uses an application to author and publish documents. The application
+adapts its UI to the access privileges in order to distinguish between allowed
+(actionable) and disallowed features for different permission groups. The
+application can make use of information to assist Guinan based on what it is
+allowed to perform, the public, as well as any other group.
+
+For example, for user level permission, if the application is not granted
+[=write access=] on the resource that Guinan is currently editing, the UI can
+disable the "Save" button in the menu. Guinan also wants to know if the
+content they are updating is granted [=read access=] to the public -
+consequently, eg. if it can be liked, bookmarked, archived by everyone.
+
+
 ## Privacy ## {#uc-privacy}
 
 ### Limiting access to who else is permitted ### {#uc-whopermitted}


### PR DESCRIPTION
Based off a number of existing discussions and work:

* https://github.com/solid/authorization-panel/issues/58
* https://github.com/linkeddata/dokieli/issues/96
* https://github.com/linkeddata/dokieli/issues/137
* https://github.com/solid/specification/issues/171

Certainly there are other issues lying around... and this is a fairly common. It also goes along with some of the other use cases.

Aside: https://github.com/solid/specification/pull/210