### PR TITLE
Use case: group membership vc

### DIFF
--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1074,15 +1074,15 @@ the [=resource=] and needing administrator assistance to recover.
 
 ### Possesion of a group membership verifiable credential ### {#group-membership-vc}
 
-Omni Corp. granted Acme Corp. read-write access to three of their projects: A, B and C.
-This grant allows all Acme Corp. employees to have that access as long as they can
-present a membership credential issued by Acme Corp. At the time of the grant,
-Omni Corp. notifies Acme Corp., detailing pertinent access details,
-including the membership credential requirement for Acme Corp. employees.
-Alice works for Acme Corp. and can now access the Omni Corp. projects A, B and C.
-using her membership credential issued by Acme Corp. Acme Corp. doesn't maintain
-a public list of their employees, and Omni Corp. can not know who is employed by Acme Corp.
-unless that person presents a verifiable credential.
+Omni Corp granted Acme Corp read-write access to three of their projects: A, B,
+and C. This grant allows all Acme Corp employees to have that access as long as
+they can present a membership credential issued by Acme Corp. At the time of
+the grant, Omni Corp notifies Acme Corp, detailing pertinent access details,
+including the membership credential requirement for Acme Corp employees. Acme
+Corp doesn't maintain a public list of their employees, so Omni Corp cannot
+know who is employed by Acme Corp unless that person presents a verifiable
+credential. Alice works for Acme Corp, and can now access the Omni Corp
+projects A, B, and C, using her membership credential issued by Acme Corp.
 
 ### Possession of a verifiable credential ### {#capabilities-vc}
 

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1075,14 +1075,14 @@ the [=resource=] and needing administrator assistance to recover.
 ### Possesion of a group membership verifiable credential ### {#group-membership-vc}
 
 Omni Corp. granted Acme Corp. read-write access to their online store front.
-This grant allows all Acme Corp. to have that access as long as they can
-present membership credential issued by Acme Corp. At the time of the grant
-Omni Corp. notified Acme Corp. about that grant and all access details,
-including membership credential requirement for Acme Corp. members.
-Alice who works for Acme Corp. now can access Omni Corp. online store front
+This grant allows all Acme Corp. employees to have that access as long as they can
+present a membership credential issued by Acme Corp. At the time of the grant,
+Omni Corp. notifies Acme Corp., detailing pertinent access details,
+including the membership credential requirement for Acme Corp. employees.
+Alice works for Acme Corp. and can now access the Omni Corp. online store front
 using her membership credential issued by Acme Corp. Acme Corp. doesn't maintain
-public list of their members, and Omni Corp. can not know who is Acme Corp.
-member unless that person presents a verifiable credential.
+a public list of their employees, and Omni Corp. can not know who is employed by Acme Corp.
+unless that person presents a verifiable credential.
 
 ### Possession of a verifiable credential ### {#capabilities-vc}
 

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1074,14 +1074,14 @@ the [=resource=] and needing administrator assistance to recover.
 
 ### Possesion of a group membership verifiable credential ### {#group-membership-vc}
 
-Omni Inc. granted Acme Inc. read-write access to their online store front.
-This grant allows all Acme Inc. to have that access as long as they can
-present membership credential issued by Acme Inc. At the time of the grant
-Omni Inc. notified Acme Inc. about that grant and all access details,
-including membership credential requirement for Acme Inc. members.
-Alice who works for Acme Inc. now can access Omni Inc. onlne store front
-using her membership credential issued by Acme Inc. Acme Inc. doesn't maintain
-public list of their members, and Omni Inc. can not know who is Acme Inc.
+Omni Corp. granted Acme Corp. read-write access to their online store front.
+This grant allows all Acme Corp. to have that access as long as they can
+present membership credential issued by Acme Corp. At the time of the grant
+Omni Corp. notified Acme Corp. about that grant and all access details,
+including membership credential requirement for Acme Corp. members.
+Alice who works for Acme Corp. now can access Omni Corp. online store front
+using her membership credential issued by Acme Corp. Acme Corp. doesn't maintain
+public list of their members, and Omni Corp. can not know who is Acme Corp.
 member unless that person presents a verifiable credential.
 
 ### Possession of a verifiable credential ### {#capabilities-vc}

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1072,6 +1072,18 @@ the [=resource=] and needing administrator assistance to recover.
 
 ## Capabilities ## {#uc-capabilities}
 
+### Possesion of a group membership verifiable credential ### {#group-membership-vc}
+
+Omni Inc. granted Acme Inc. read-write access to their online store front.
+This grant allows all Acme Inc. to have that access as long as they can
+present membership credential issued by Acme Inc. At the time of the grant
+Omni Inc. notified Acme Inc. about that grant and all access details,
+including membership credential requirement for Acme Inc. members.
+Alice who works for Acme Inc. now can access Omni Inc. onlne store front
+using her membership credential issued by Acme Inc. Acme Inc. doesn't maintain
+public list of their members, and Omni Inc. can not know who is Acme Inc.
+member unless that person presents a verifiable credential.
+
 ### Possession of a verifiable credential ### {#capabilities-vc}
 
 Oscar has a medical condition that causes random and very serious seizures

--- a/proposals/wac-ucr/index.bs
+++ b/proposals/wac-ucr/index.bs
@@ -1074,12 +1074,12 @@ the [=resource=] and needing administrator assistance to recover.
 
 ### Possesion of a group membership verifiable credential ### {#group-membership-vc}
 
-Omni Corp. granted Acme Corp. read-write access to their online store front.
+Omni Corp. granted Acme Corp. read-write access to three of their projects: A, B and C.
 This grant allows all Acme Corp. employees to have that access as long as they can
 present a membership credential issued by Acme Corp. At the time of the grant,
 Omni Corp. notifies Acme Corp., detailing pertinent access details,
 including the membership credential requirement for Acme Corp. employees.
-Alice works for Acme Corp. and can now access the Omni Corp. online store front
+Alice works for Acme Corp. and can now access the Omni Corp. projects A, B and C.
 using her membership credential issued by Acme Corp. Acme Corp. doesn't maintain
 a public list of their employees, and Omni Corp. can not know who is employed by Acme Corp.
 unless that person presents a verifiable credential.


### PR DESCRIPTION
This use case presents scenario of group based access which doesn't require public group member list. Neither party granting access maintaining their own list of members in group they grant access to.

**EDIT**: https://solid.github.io/authorization-panel/wac-ucr/#capabilities-vc provides more complicated use case which depends on existence of broader trust network. Use case in this PR only requires membership credential issued by a known party. It also directly addresses known issues with group based access where list of group members is not accessible to the guard enforcing access policy.