### PR TITLE
Omit solution-centric references

### DIFF
--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -68,9 +68,6 @@ a Solid authorization system should support. The [[#requirements]] in this
 document are derived from those use cases, and will inform and guide
 the contents of a subsequent specification proposal.
 
-[[#limitations]] highlights the [[#usecases]] that
-the current authorization system fails to satisfy.
-
 Use Cases {#usecases}
 ================================================================================
 
@@ -1858,30 +1855,6 @@ or limiting access to a [=resource=] or [=collection=] by an [=agent=].
 <div class="assertion">    
   Related use cases: [[#conditional-control]]
 </div>
-
-Limitations of Web Access Control {#limitations}
-================================================================================
-
-[Web Access Control](https://github.com/solid/web-access-control-spec)
-does not satisfy the following use cases:
-
-* [[#inheritance-adding]]
-* [[#inheritance-modifying]]
-* [[#inheritance-forcing]]
-* [[#inheritance-extended]]
-* [[#collection-readcreatedelete]]
-* [[#conditional-time]]
-* [[#conditional-tag]]
-* [[#conditional-filter]]
-* [[#conditional-control]]
-* [[#conditional-payment]]
-* [[#uc-applications]]
-* [[#uc-trustedissuers]]
-* [[#uc-validation]]
-* [[#capabilities-vc]]
-* [[#capabilities-link]]
-* [[#uc-minimalcredentials]]
-* [[#uc-limituri]]
 
 Definitions {#definitions}
 ================================================================================


### PR DESCRIPTION
Solution-centric references have no place in a UCR document.

Had there been a prior UCR document, then this current UCR would be an addendum to the prior UCR as additional needs are brought forward, and not because of particular solutions.