### PR TITLE
+ characterize axes for access relationships

### DIFF
--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1111,7 +1111,7 @@ later, but no others.
 Three axes describe the relationships which propagate access rules:
 
 1. Relationships may be `direct` or `indirect`, e.g., `report-1` references `measurement-2`, which in turn references `instrument-3`.
-2. Relationships may be `forward` or `inverse`, e.g., `slides-4` references `report-1`, so the permissions associated with `report-1` also apply to `slides-4`.
+2. Relationships may be `forward` or `inverse`, e.g., `slide-4` references `report-1`, so the permissions associated with `report-1` also apply to `slide-4`.
 3. Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g., a document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
 
 <div class="assertion">

--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1108,6 +1108,12 @@ This ensures that the senior research team members will be able to read
 measurements referenced by `/reports/report-1`, or any references added to it
 later, but no others.
 
+Three axes describe the relationships which propagate access rules:
+
+1. Relationships may be `direct` or `indirect`, e.g. `report-1` references `measurement-2`, which in turn references `instrument-3`.
+2. Relationships may be `forard` or `inverse`, e.g. `slides-4` reference `report-1` so the permissions associated with `report-1` also apply to `slides-4`.
+3. Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g. document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
+
 <div class="assertion">
 
 * [[#req-agent-group]]

--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1110,9 +1110,9 @@ later, but no others.
 
 Three axes describe the relationships which propagate access rules:
 
-1. Relationships may be `direct` or `indirect`, e.g. `report-1` references `measurement-2`, which in turn references `instrument-3`.
-2. Relationships may be `forard` or `inverse`, e.g. `slides-4` reference `report-1` so the permissions associated with `report-1` also apply to `slides-4`.
-3. Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g. document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
+1. Relationships may be `direct` or `indirect`, e.g., `report-1` references `measurement-2`, which in turn references `instrument-3`.
+2. Relationships may be `forward` or `inverse`, e.g., `slides-4` references `report-1`, so the permissions associated with `report-1` also apply to `slides-4`.
+3. Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g., a document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
 
 <div class="assertion">
 

--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1108,11 +1108,11 @@ This ensures that the senior research team members will be able to read
 measurements referenced by `/reports/report-1`, or any references added to it
 later, but no others.
 
-Three axes may describe the relationships which propagate access rules:
+There may be different ways to describe the relationships which propagate access rules, for example:
 
-1. Relationships may be `direct` or `indirect`, e.g., `report-1` references `measurement-2`, which in turn references `instrument-3`.
-2. Relationships may be `forward` or `inverse`, e.g., `slide-4` references `report-1`, so the permissions associated with `report-1` also apply to `slide-4`.
-3. Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g., a document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
+* Relationships may be `direct` or `indirect`, e.g., `report-1` references `measurement-2`, which in turn references `instrument-3`.
+* Relationships may be `forward` or `inverse`, e.g., `slide-4` references `report-1`, so the permissions associated with `report-1` also apply to `slide-4`.
+* Relationships may be asserted in the `referring` document, the `referenced` document, or some third document, e.g., a document other than `report-1` which contains the relationship linking `report-1` to `measurement-2`.
 
 <div class="assertion">
 

--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1108,7 +1108,7 @@ This ensures that the senior research team members will be able to read
 measurements referenced by `/reports/report-1`, or any references added to it
 later, but no others.
 
-Three axes describe the relationships which propagate access rules:
+Three axes may describe the relationships which propagate access rules:
 
 1. Relationships may be `direct` or `indirect`, e.g., `report-1` references `measurement-2`, which in turn references `instrument-3`.
 2. Relationships may be `forward` or `inverse`, e.g., `slide-4` references `report-1`, so the permissions associated with `report-1` also apply to `slide-4`.


### PR DESCRIPTION
Access relationships may span multiple hops, may include incoming arcs, and may appear in any document.
This PR clarifies the axis vocabulary we'll need to standardize the scope of such access relationships.