### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: discussions
+    url: https://github.com/solid/authorization-panel/discussions
+    about: Open discussion should happen here. Issues require clear acceptance citeria for resolving them.
+  - name: chatroom
+    url: https://gitter.im/solid/authorization-panel
+    about: Public gitter channel for quick questions and real time discussion (as much as different timezones allow)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Open discussion should happen here. Issues require clear acceptance citeria for resolving them.
   - name: chatroom
     url: https://gitter.im/solid/authorization-panel
-    about: Public gitter channel for quick questions and real time discussion (as much as different timezones allow)
+    about: Public gitter channel for quick questions and real time discussion (as much as different timezones allow).

--- a/.github/ISSUE_TEMPLATE/draft-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/draft-suggestion.md
@@ -1,0 +1,18 @@
+---
+name: Proposals suggestion
+about: Suggestion for improving on of existing proposals
+---
+
+## On proposal
+
+Which proposal your suggestion is intended for? (ACP, WAC+)
+
+## Details
+
+
+
+## Acceptance criteria
+
+What actions are needed to resolve this issue? (checklist)
+
+* [ ] 

--- a/.github/ISSUE_TEMPLATE/draft-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/draft-suggestion.md
@@ -1,11 +1,11 @@
 ---
 name: Proposals suggestion
-about: Suggestion for improving on of existing proposals
+about: Suggestion for improving existing proposals
 ---
 
 ## On proposal
 
-Which proposal your suggestion is intended for? (ACP, WAC+)
+Which proposal is your suggestion intended for? (e.g. ACP, WAC+)
 
 ## Details
 

--- a/.github/ISSUE_TEMPLATE/use-case-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/use-case-suggestion.md
@@ -1,0 +1,18 @@
+---
+name: Use cases suggestion
+about: Suggestion for improving use cases document
+---
+
+## On use case
+
+Which existing use case your suggestion is intended for? (or a new use case)
+
+## Details
+
+
+
+## Acceptance criteria
+
+What actions are needed to resolve this issue? (checklist)
+
+* [ ] 

--- a/.github/ISSUE_TEMPLATE/use-case-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/use-case-suggestion.md
@@ -5,7 +5,7 @@ about: Suggestion for improving use cases document
 
 ## On use case
 
-Which existing use case your suggestion is intended for? (or a new use case)
+Which existing use case is your suggestion intended for? (or a new use case)
 
 ## Details
 


### PR DESCRIPTION
As discussed during our call today. This will show links to github discussion and gitter chatroom. As well as two option to create issues:

* Proposal suggestion
* Use case suggestion

We can add more option with appropriate templates as needed. We can also add PR templates, for example one for survey responses. 