### PR TITLE
Remove references to acp:AccessPolicy

### DIFF
--- a/proposals/acp/definitions.md
+++ b/proposals/acp/definitions.md
@@ -64,11 +64,7 @@
 
 ## Access Policy Resource
 
-*   An Access Policy Resource (APR) is a resource containing metadata describing the [Access Policies](#access-policy) and [Access Rules](#access-rule) that can be used to determine agent (or group) access to resources. Any resource can act as an Access Policy Resource.
-*   An APR contains zero or more [Access Policies](#access-policy) and zero or more [Access Rules](#access-rule) used by the [Access Policies](#access-policy).
-*   [Access Policies](#access-policy) and [Access Rules](#access-rule) can also be defined in [Access Control Resources](#access-control-resource), but defining them in an APR means they are reusable by agents and manageable by agents without those agents needing access to ACR metadata. 
-
-![alt_text](diagrams/apr.svg "image_tooltip")
+An Access Policy Resource (APR) was an envisaged type of resource that would contain Access Policies and Access Rules. This type of resource was removed and in the current proposal, Access Policies and Access Rules can be defined in any resource. See also: https://github.com/solid/authorization-panel/issues/142#issuecomment-736584841
 
 ## Access Policy
 

--- a/proposals/acp/use-cases.md
+++ b/proposals/acp/use-cases.md
@@ -239,8 +239,6 @@ Content-Type: text/turtle
 ```Turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-
-<> a acp:AccessControlResource .
  
 # Policies
 
@@ -671,8 +669,6 @@ Content-Type: text/turtle
 ```Turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-
-<> a acp:AccessControlResource .
  
 # Policies
 
@@ -789,8 +785,6 @@ Content-Type: text/turtle
 ```Turtle
 prefix acp: <http://www.w3.org/ns/solid/acp#>
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-<> a acp:AccessControlResource .
  
 # Policies
 

--- a/proposals/acp/use-cases.md
+++ b/proposals/acp/use-cases.md
@@ -37,7 +37,7 @@ HTTP/1.1 201 Created
 Location: /policies
 ```
 
-Create the personal [Access Policy Resource](definitions.md#access-policy-resource). We should use the Location HTTP header in the response from the previous POST because the Slug header may be ignored by the server. 
+Create the personal Resource. We should use the Location HTTP header in the response from the previous POST because the Slug header may be ignored by the server. 
 
 ```HTTP
 PUT /policies/personal HTTP/1.1
@@ -983,7 +983,7 @@ INSERT DATA {
 HTTP/1.1 204 No Content
 ```
 
-Notice that we added the policy and rule directly to the ACR for document1 rather than to an external [Access Policy Resource](definitions.md#access-policy-resource). When policies and rules are not reusable, it can be more convenient to add them directly to the relevant ACR.
+Notice that we added the policy and rule directly to the ACR for document1 rather than to an external Resource. When policies and rules are not reusable, it can be more convenient to add them directly to the relevant ACR.
 
 ### 2.2.3 Read-append access to a collection
 

--- a/proposals/acp/use-cases.md
+++ b/proposals/acp/use-cases.md
@@ -48,7 +48,6 @@ Content-Type: text/turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<> a acp:AccessControlResource .
  
 # Policies
 

--- a/proposals/acp/use-cases.md
+++ b/proposals/acp/use-cases.md
@@ -48,17 +48,17 @@ Content-Type: text/turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<> a acp:AccessPolicyResource .
+<> a acp:AccessControlResource .
  
 # Policies
 
 <#personalTrusted>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Write, acp:Read ;
   acp:allOf <#editorFriends> .
 
 <#podControl>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Write, acp:Read ;
   acp:allOf <#accessControllers> .
 
@@ -175,7 +175,7 @@ prefix : <https://alice.pod/policies/personal#>
 INSERT DATA { 
 
 <#commentsOnly>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Append, acp:Read ;
   acp:allOf <#commenters> .
 
@@ -241,12 +241,12 @@ Content-Type: text/turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<> a acp:AccessPolicyResource .
+<> a acp:AccessControlResource .
  
 # Policies
 
 <#publicAccess>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#public> .
 
@@ -383,7 +383,7 @@ prefix : <https://alice.pod/policies/personal#>
 INSERT DATA { 
 
 <#recommend>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Append ;
   acp:allOf <#canRecommend> .
 
@@ -463,7 +463,7 @@ prefix : <https://alice.pod/policies/personal#>
 INSERT DATA { 
 
 <#namedRead>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#readers> .
 
@@ -673,17 +673,17 @@ Content-Type: text/turtle
 @prefix acp: <http://www.w3.org/ns/solid/acp#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<> a acp:AccessPolicyResource .
+<> a acp:AccessControlResource .
  
 # Policies
 
 <#openMaterial>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#openWorkshop> .
 
 <#openInteraction>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Write, acp:Read ;
   acp:allOf <#openWorkshop> .
 
@@ -791,12 +791,12 @@ Content-Type: text/turtle
 prefix acp: <http://www.w3.org/ns/solid/acp#>
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-<> a acp:AccessPolicyResource .
+<> a acp:AccessControlResource .
  
 # Policies
 
 <#attendeesAccess>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#attendees> .
 
@@ -883,7 +883,7 @@ prefix : <https://alice.pod/policies/personal#>
 INSERT DATA { 
 
 <#jobRead>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#jobContacts> .
 
@@ -966,7 +966,7 @@ prefix acp: <http://www.w3.org/ns/solid/acp#>
 INSERT DATA { 
 
 <#MiloUpdate>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Write ;
   acp:allOf <#milo> .
 
@@ -1004,7 +1004,7 @@ prefix acp: <http://www.w3.org/ns/solid/acp#>
 INSERT DATA { 
 
 <#bobAdditions>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read, acp:Append ;
   acp:allOf <#bob> .
 
@@ -1034,7 +1034,7 @@ prefix acp: <http://www.w3.org/ns/solid/acp#>
 INSERT DATA { 
 
 <#creatorCanRead>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#creators> .
 
@@ -1073,12 +1073,12 @@ prefix acp: <http://www.w3.org/ns/solid/acp#>
 INSERT DATA { 
 
 <#colleagueReads>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf <#colleagues> .
 
 <#colleagueComments>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Append ;
   acp:allOf <#colleagues> .
 
@@ -1110,7 +1110,7 @@ prefix acp: <http://www.w3.org/ns/solid/acp#>
 INSERT DATA { 
 
 <#colleagueEditComments>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Write ;
   acp:allOf <#creators> .
 
@@ -1144,7 +1144,7 @@ prefix : <https://alice.pod/policies/personal#>
 INSERT DATA { 
 
 <#jobOpportunities>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Append ;
   acp:allOf :jobContacts .
 
@@ -1180,7 +1180,7 @@ INSERT DATA {
 <> acp:access <#bobAsController> .
 
 <#bobAsController>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read, acp:Write ;
   acp:allOf <#bob> .
 

--- a/proposals/acp/wac-acp-diff.ttl
+++ b/proposals/acp/wac-acp-diff.ttl
@@ -40,7 +40,7 @@ acp:authorizes a rdf:Property;
 [ owl:propertyChainAxiom ( acp:accessControl acp:authorizes ) ]  rdfs:subPropertyOf [ owl:inverseOf acl:accessTo ] .
 
 # this should force the following 
-acp:AccessPolicy owl:equivalentClass acl:Authorization .
+acp:Policy owl:equivalentClass acl:Authorization .
 
 # also tells us that  
 acl:accessControl rdfs:range acp:AccessControlResource .

--- a/proposals/wac-acp-diff-story.md
+++ b/proposals/wac-acp-diff-story.md
@@ -85,8 +85,8 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 }
 
 # can do what
-<AccessPolicyShape> {
-  a [acp:AccessPolicy] ? ;
+<PolicyShape> {
+  a [acp:Policy] ? ;
   acp:allow [acp:Write acp:Read acp:Append] + ;
   acp:allOf @<RuleShape> ;
 }
@@ -96,15 +96,15 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 <AccessControlShape> {
   a [acp:AccessControl] ? ;
   (
-      acp:apply @<AccessPolicyShape>
+      acp:apply @<PolicyShape>
     |
-      ( acp:applyConstant @<AccessPolicyShape> ;
-        acp:applyMembersConstant @<AccessPolicyShape> ;
+      ( acp:applyConstant @<PolicyShape> ;
+        acp:applyMembersConstant @<PolicyShape> ;
       )
   )
 }
 ```
-([try it](http://shex.io/webapps/shex.js/doc/shex-simple?schema=PREFIX%20acp%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fsolid%2Facp%23%3E%0APREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0A%0A%23%20Policies%0A%0A%3CAccessPolicyShape%3E%20%7B%0A%20%20a%20%5Bacp%3AAccessPolicy%5D%20%3F%20%3B%0A%20%20acp%3Aallow%20%5Bacp%3AWrite%20acp%3ARead%5D%2B%20%3B%0A%20%20acp%3AallOf%20%40%3CRuleShape%3E%20%3B%0A%7D%0A%0A%3CRuleShape%3E%20%7B%0A%20%20a%20%5Bacp%3ARule%5D%20%3F%20%3B%0A%20%20acp%3Aagent%20IRI%20%3B%0A%7D%0A&data=PREFIX%20acp%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fsolid%2Facp%23%3E%0APREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0A%0A%3C%23i%3E%0A%20%20acp%3Aaccess%20%3C%23podControl%3E%20%3B%0A%20%20acp%3AaccessMembers%20%3C%23podControl%3E%20.%0A%3C%23myPodAccess%3E%0A%20%20a%20acp%3AAccessControl%20%3B%0A%20%20acp%3AapplyConstant%20%3C%23podControl%3E%20%3B%0A%20%20acp%3AapplyMembersConstant%20%3C%23podControl%3E%20.%0A%3C%23resumeAssistance%3E%0A%20%20a%20acp%3AAccessControl%20%3B%0A%20%20acp%3Aapply%20%3C%23personalTrusted%3E%20.%0A%0A%23%20Policies%0A%0A%3C%23personalTrusted%3E%0A%20%20a%20acp%3AAccessPolicy%20%3B%0A%20%20acp%3Aallow%20acp%3AWrite%2C%20acp%3ARead%20%3B%0A%20%20acp%3AallOf%20%3C%23editorFriends%3E%20.%0A%0A%3C%23podControl%3E%0A%20%20a%20acp%3AAccessPolicy%20%3B%0A%20%20acp%3Aallow%20acp%3AWrite%2C%20acp%3ARead%20%3B%0A%20%20acp%3AallOf%20%3C%23accessControllers%3E%20.%0A%0A%23%20Rules%0A%0A%3C%23editorFriends%3E%0A%20%20a%20acp%3ARule%20%3B%0A%20%20acp%3Aagent%20%3Chttps%3A%2F%2Fbob.pod%2Fprofile%2Fcard%23me%3E%20.%0A%0A%3C%23accessControllers%3E%0A%20%20a%20acp%3ARule%20%3B%0A%20%20acp%3Aagent%20%3Chttps%3A%2F%2Falice.pod%2Fprofile%2Fcard%23me%3E%20.%0A&manifestURL=http%3A%2F%2Fshex.io%2Fwebapps%2Fshex.js%2Fexamples%2Fmanifest.json&shape-map=%7BFOCUS%20acp%3Aallow%20_%7D%40%3CAccessPolicyShape%3E&interface=human&success=proof&regexpEngine=eval-threaded-nerr))
+([try it](http://shex.io/webapps/shex.js/doc/shex-simple?schema=PREFIX%20acp%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fsolid%2Facp%23%3E%0APREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0A%0A%23%20Policies%0A%0A%3CPolicyShape%3E%20%7B%0A%20%20a%20%5Bacp%3APolicy%5D%20%3F%20%3B%0A%20%20acp%3Aallow%20%5Bacp%3AWrite%20acp%3ARead%5D%2B%20%3B%0A%20%20acp%3AallOf%20%40%3CRuleShape%3E%20%3B%0A%7D%0A%0A%3CRuleShape%3E%20%7B%0A%20%20a%20%5Bacp%3ARule%5D%20%3F%20%3B%0A%20%20acp%3Aagent%20IRI%20%3B%0A%7D%0A&data=PREFIX%20acp%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fsolid%2Facp%23%3E%0APREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0A%0A%3C%23i%3E%0A%20%20acp%3Aaccess%20%3C%23podControl%3E%20%3B%0A%20%20acp%3AaccessMembers%20%3C%23podControl%3E%20.%0A%3C%23myPodAccess%3E%0A%20%20a%20acp%3AAccessControl%20%3B%0A%20%20acp%3AapplyConstant%20%3C%23podControl%3E%20%3B%0A%20%20acp%3AapplyMembersConstant%20%3C%23podControl%3E%20.%0A%3C%23resumeAssistance%3E%0A%20%20a%20acp%3AAccessControl%20%3B%0A%20%20acp%3Aapply%20%3C%23personalTrusted%3E%20.%0A%0A%23%20Policies%0A%0A%3C%23personalTrusted%3E%0A%20%20a%20acp%3APolicy%20%3B%0A%20%20acp%3Aallow%20acp%3AWrite%2C%20acp%3ARead%20%3B%0A%20%20acp%3AallOf%20%3C%23editorFriends%3E%20.%0A%0A%3C%23podControl%3E%0A%20%20a%20acp%3APolicy%20%3B%0A%20%20acp%3Aallow%20acp%3AWrite%2C%20acp%3ARead%20%3B%0A%20%20acp%3AallOf%20%3C%23accessControllers%3E%20.%0A%0A%23%20Rules%0A%0A%3C%23editorFriends%3E%0A%20%20a%20acp%3ARule%20%3B%0A%20%20acp%3Aagent%20%3Chttps%3A%2F%2Fbob.pod%2Fprofile%2Fcard%23me%3E%20.%0A%0A%3C%23accessControllers%3E%0A%20%20a%20acp%3ARule%20%3B%0A%20%20acp%3Aagent%20%3Chttps%3A%2F%2Falice.pod%2Fprofile%2Fcard%23me%3E%20.%0A&manifestURL=http%3A%2F%2Fshex.io%2Fwebapps%2Fshex.js%2Fexamples%2Fmanifest.json&shape-map=%7BFOCUS%20acp%3Aallow%20_%7D%40%3CPolicyShape%3E&interface=human&success=proof&regexpEngine=eval-threaded-nerr))
 
 As above, Jezebel can let Bartholomew copy her homework by editing the ACL document associated with `</courses/8.04/assignment-1>` by the `acp:accessControl` link header (e.g., `</courses/8.04/assignment-1?access>`):
 
@@ -112,7 +112,7 @@ As above, Jezebel can let Bartholomew copy her homework by editing the ACL docum
 _:bart-copies-assignment-1
   a acl:AccessControl ;
   acp:apply [
-    a acp:AccessPolicy ;
+    a acp:Policy ;
     acp:allow acp:Read ;
     acp:allOf [
       acp:agent <http://solid.example/users/bart#id>
@@ -123,7 +123,7 @@ _:bart-copies-assignment-1
 She could instead move that policy someplace independent from the existence of `</courses/8.04/assignment-1>`, e.g., `</myAccessPolicies>`, so it won't disappear if she deletes or renames `assignment-1`:
 ``` turtle
 <#bart-copies-my-homework>
-  a acp:AccessPolicy ;
+  a acp:Policy ;
   acp:allow acp:Read ;
   acp:allOf [
     acp:agent <http://solid.example/users/bart#id>


### PR DESCRIPTION
Fixes https://github.com/solid/authorization-panel/issues/145.

I think we can remove the straight references to `acp:AccessPolicy` in sample code for now to avoid confusion. In the longer term, once the first draft of a draft of ACP gets merged into main, we could move the first acp proposal to the archive folder or delete it from the `main` branch.

cc @bblfish 
