### PR TITLE
updates and improvements after aaron's fixes

### DIFF
--- a/meetings/2021-10-13.md
+++ b/meetings/2021-10-13.md
@@ -166,18 +166,17 @@ Then after an assignee (scribe, moderator, CG chair...) merges. This could be au
 
 * **Matthieu**: It is unclear to me this is an efficiency problem. If we are talking about a cache. ACP has 1:1 resources/ACR and only the first level is not reusable. I don't see how to make the cache more efficient since ACP de facto reduces redundancies. I am not convinced that something can't be optimised ahead of time...
 
-* **Aaron**: there are two kinds of interactions with acp/wac: there is update and read, of access control rules. Both ACP and WAC make different optimisation decisions. 
-  * What wac does is it makes writes to acl easy and quick. But read is more complicated as Henry pointed out. so wac puts simplicity on writes and complexity on reads. 
+* **Aaron**: there are two kinds of interactions with acp/wac: there is update and read of access control rules. Both ACP and WAC make different optimisation decisions. 
+  * What wac does is it makes writes to acl easy and quick. But read is more complicated as Henry pointed out. So WAC puts simplicity on writes and complexity on reads. 
   * ACP is the other way around: reads are very quick and writes are more complex. But since most uses of WAC are reading this makes sense to me.
 
-* when someone is building a WAC system they'll find, (I have built several wac sytesms) the need to build caching systems anyway... on an engineering side.. these request happen so fast, you'll need to build a cache any way.
-* AC: there are two kinds of interactions with acp/wac: there is update and read (i.e., enforcement and change in access control). what wac does is, makes writes to acl easy and quick. read is more complicated as henry pointed out. so wac puts simplicity on writes and complexity on reads. acp is the other way around. when someone is building a wac system they'll find, (i've build several wac systems) there is a need to build cache systems any way.. on an engineering side.. these request happen so frequently.. you'll need to build a cache any way.
+* When someone is building a WAC system they'll find, (I have built several wac sytesms) the need to build caching systems anyway... on an engineering side.. these request happen so fast, you'll need to build a cache any way.
 
 * **Henry**: Aaron described it well, but I believe we could do better on both sides, e.g., WAC can do better by allowing clients to find the active ACR, and ACP does not need to require so many ACRs, especially when they are all duplicating a default rule. For WAC, finding the active ACR requires just one additional link header, pointing to the active ACR. That would save `2n+1` requests (where `n` is the number of folders between a resource and the active one). Then ACP could adopt the default system of WAC, and not require every resource to have its ACR, thereby also reducing the number of requests.
 
 * **KjetilK**: Agree with Aaron. WAC needs to be implemented with caching anyway. also I agree with your assessment on `2n+1`, but that has a relatively trivial solution to point at the effective resource. Trying to look at this more fundamental analysis angle, we want Solid to grow exponentially, and grow on very large servers too, creating a huge URI space. So we have a problem in that we need to limit that exponential time increase in some way. We need to take into account disk speed and Moore's law, and possibly bring it down to something that's not exponential. There are things like spinning disks which only have linear improvement. The problem is that ACP is efficient on read, but on write, it is terrible, because on every write, it has to propagate the change of rules to children; that goes with the need to block all accesses. I have to admit that I am not that clear on how propagation happens in ACP. I also acknowledge that I'm not particularly good at this.
 
-* AC: a lot can be addressed through implementation detail. re: Henry's point on precomputed cache, there are all kinds of caches. Don't need to materialize all data in ACR cache; it can be lazy. It is not necessary to block on reads. Those implementation details are allowable within the spec.
+* **Aaron**: a lot can be addressed through implementation detail. re: Henry's point on precomputed cache, there are all kinds of caches. Don't need to materialize all data in ACR cache; it can be lazy. It is not necessary to block on reads. Those implementation details are allowable within the spec.
 
 * **Matthieu**: ACP makes everything reusable all the time no matter if working on hierarchy or not.
 


### PR DESCRIPTION
These are fixes I made after Aaron's corrections. We were working on them simultaneously so I had a a lot of work dealing with merge conflicts later (hence two PRs that were aborted).

Note: in the future could we have the scribe create short 80 or 70 char lines so that one can edit small chunks of text at a time. 
Here a small typo changes a whole paragraph, increasing the likelihood of merge conflicts.

