### PR TITLE
added evaluation for 2.5.2 client-constraints

### DIFF
--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -4,28 +4,23 @@ https://solid.github.io/authorization-panel/authorization-ucr/#uc-client-constra
 
 ### ACP
 
-ACP allows combining multiple matchers with `acp:allOf`, this allows expressing policy which uses `acp:agent` and `acp:client` in combined matchers.
+ACP requires that if `acp:agent` and `acp:client` are present in the matcher, both need to be satisfied.
 
 ```ttl
 PREFIX acp: <http://www.w3.org/ns/solid/acp#>
 PREFIX acl: <http://www.w3.org/ns/auth/acl#>
 PREFIX ex: <https://example.com/>
 
-ex:accessControlResourceA
-  acp:resource ex:resourceX ;
-  acp:accessControl ex:accessControlB .
-
-ex:accessControlB acp:apply ex:PolicyC .
-
-ex:PolicyC
-  acp:allOf ex:agentMatcherD, ex:clientMatcherD ;
+ex:ReaderAgentPolicy
+  acp:anyOf ex:BobMatcher, ex:AliceMatcher ;
   acp:allow acl:Read .
 
-ex:agentMatcherD
-  acp:agent ex:Bob .
-
-ex:clientMatcherD
+ex:BobMatcher
+  acp:agent ex:Bob ;
   acp:client ex:Projectron .
-```
 
-`ex:Policy` allows acces to `ex:Projectron` but only if `ex:Bob` is using it.
+ex:AliceMatcher
+  acp:agent ex:Alice ;
+  acp:client ex:Projectron, ex:OtherApp .
+
+`ex:BobMatcher` allows access to `ex:Projectron` but only if `ex:Bob` is using it.

--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -22,7 +22,6 @@ ex:BobMatcher
 ex:AliceMatcher
   acp:agent ex:Alice ;
   acp:client ex:Projectron, ex:OtherApp .
-  
 ```
 
 `ex:BobMatcher` allows access to `ex:Projectron` but only if `ex:Bob` is using it.

--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -22,4 +22,7 @@ ex:BobMatcher
 ex:AliceMatcher
   acp:agent ex:Alice ;
   acp:client ex:Projectron, ex:OtherApp .
+  
+```
+
 `ex:BobMatcher` allows access to `ex:Projectron` but only if `ex:Bob` is using it.

--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -1,0 +1,31 @@
+# Limiting application access while not acting as resource controller
+
+https://solid.github.io/authorization-panel/authorization-ucr/#uc-client-constraints
+
+### ACP
+
+ACP allows combining multiple matchers with `acp:allOf`, this allows expressin policy which uses `acp:agent` and `acp:client` in combined matchers.
+
+```ttl
+PREFIX acp: <http://www.w3.org/ns/solid/acp#>
+PREFIX acl: <http://www.w3.org/ns/auth/acl#>
+PREFIX ex: <https://example.com/>
+
+ex:accessControlResourceA
+  acp:resource ex:resourceX ;
+  acp:accessControl ex:accessControlB .
+
+ex:accessControlB acp:apply ex:PolicyC .
+
+ex:PolicyC
+  acp:allOf ex:agentMatcherD, ex:clientMatcherD ;
+  acp:allow acl:Read .
+
+ex:agentMatcherD
+  acp:agent ex:Bob .
+
+ex:clientMatcherD
+  acp:client ex:Projectron .
+```
+
+`ex:Policy` allows acces to `ex:Projectron` but only if `ex:Bob` is using it.

--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -22,5 +22,4 @@ ex:BobMatcher
 ex:AliceMatcher
   acp:agent ex:Alice ;
   acp:client ex:Projectron, ex:OtherApp .
-
 `ex:BobMatcher` allows access to `ex:Projectron` but only if `ex:Bob` is using it.

--- a/proposals/evaluation/uc-2.5.2-client-constraints.md
+++ b/proposals/evaluation/uc-2.5.2-client-constraints.md
@@ -4,7 +4,7 @@ https://solid.github.io/authorization-panel/authorization-ucr/#uc-client-constra
 
 ### ACP
 
-ACP allows combining multiple matchers with `acp:allOf`, this allows expressin policy which uses `acp:agent` and `acp:client` in combined matchers.
+ACP allows combining multiple matchers with `acp:allOf`, this allows expressing policy which uses `acp:agent` and `acp:client` in combined matchers.
 
 ```ttl
 PREFIX acp: <http://www.w3.org/ns/solid/acp#>


### PR DESCRIPTION
During the last meeting we discussed how matcher using `acp:agent` can be combined with matcher using `acp:client` to express policy for a specific user using the specific client.