### PR TITLE
Fix incorrect number of named individuals

### DIFF
--- a/proposals/acp-specification/index.html
+++ b/proposals/acp-specification/index.html
@@ -1874,7 +1874,7 @@
                   >The ACP
                   <span property="rdfs:label">Agent matcher</span> relies on the
                   <a href="#acp-agent"><code>acp:agent</code></a> predicate and
-                  three named individuals to define sets of matching
+                  the following named individuals to define sets of matching
                   agents.</span
                 ></span
               >


### PR DESCRIPTION
There are now 4 named individuals so perhaps leave the text open to the number changing again.