### PR TITLE
ACP: Add missing prefix id directive for `cito`

### DIFF
--- a/proposals/acp-specification/acp.ttl
+++ b/proposals/acp-specification/acp.ttl
@@ -1,4 +1,5 @@
 prefix acp: <http://www.w3.org/ns/solid/acp#>
+prefix cito: <http://purl.org/spar/cito/>
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl: <http://www.w3.org/2002/07/owl#>


### PR DESCRIPTION
Add missing prefix directive for `cito` prefix, in ACP ontology file.