### PR TITLE
UCR: Update obsolete bibref

### DIFF
--- a/proposals/authorization-ucr/index.bs
+++ b/proposals/authorization-ucr/index.bs
@@ -1912,7 +1912,7 @@ ability to secure access to those [=resources=] through associated
 [=authorizations=].
 
 A <dfn>resource</dfn> is the target of an HTTP request identified by a
-[[URI]], as defined in [[!RFC7231]].
+[[URI]], as defined in [[!rfc9110]].
 
 A <dfn>collection</dfn> is a [=resource=] that is representative of a set of
 other [=resources=], which may include other [=collections=].


### PR DESCRIPTION
Obsolete bibref [breaks](https://github.com/solid/authorization-panel/actions/runs/3140870105/jobs/5102710907) bikeshead build.