### PR TITLE
HTTP vocabulary base URI in pseudocode

### DIFF
--- a/proposals/acp-specification/index.html
+++ b/proposals/acp-specification/index.html
@@ -2934,10 +2934,10 @@ ex:matcherB
   <span class="k">return</span> <span class="kc">true</span>
 <span class="p">}</span>
 
-<span class="kd">const</span> <span class="nx">publicAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#PublicAgent</span><span class="dl">"</span>
-<span class="kd">const</span> <span class="nx">authenticatedAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#AuthenticatedAgent</span><span class="dl">"</span>
-<span class="kd">const</span> <span class="nx">creatorAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#CreatorAgent</span><span class="dl">"</span>
-<span class="kd">const</span> <span class="nx">ownerAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#OwnerAgent</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">publicAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#PublicAgent</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">authenticatedAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#AuthenticatedAgent</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">creatorAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#CreatorAgent</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">ownerAgent</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#OwnerAgent</span><span class="dl">"</span>
 <span class="kd">function</span> <span class="nx">agentMatches</span><span class="p">(</span><span class="nx">agent</span><span class="p">,</span> <span class="nx">context</span><span class="p">)</span> <span class="p">{</span>
   <span class="k">if</span> <span class="p">(</span><span class="nx">agent</span> <span class="o">===</span> <span class="nx">publicAgent</span><span class="p">)</span>
       <span class="k">return</span> <span class="kc">true</span>
@@ -2955,8 +2955,8 @@ ex:matcherB
       <span class="k">return</span> <span class="kc">true</span>
 <span class="p">}</span>
 
-<span class="kd">const</span> <span class="nx">publicClient</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#PublicClient</span><span class="dl">"</span>
-<span class="kd">const</span> <span class="nx">authenticatedClient</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#AuthenticatedClient</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">publicClient</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#PublicClient</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">authenticatedClient</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#AuthenticatedClient</span><span class="dl">"</span>
 <span class="kd">function</span> <span class="nx">clientMatches</span><span class="p">(</span><span class="nx">client</span><span class="p">,</span> <span class="nx">context</span><span class="p">)</span> <span class="p">{</span>
   <span class="k">if</span> <span class="p">(</span><span class="nx">client</span> <span class="o">===</span> <span class="nx">publicClient</span><span class="p">)</span>
       <span class="k">return</span> <span class="kc">true</span>
@@ -2968,8 +2968,8 @@ ex:matcherB
       <span class="k">return</span> <span class="kc">true</span>
 <span class="p">}</span>
 
-<span class="kd">const</span> <span class="nx">publicIssuer</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#PublicIssuer</span><span class="dl">"</span>
-<span class="kd">const</span> <span class="nx">authenticatedIssuer</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">https://www.w3.org/ns/solid/acp#AuthenticatedIssuer</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">publicIssuer</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#PublicIssuer</span><span class="dl">"</span>
+<span class="kd">const</span> <span class="nx">authenticatedIssuer</span> <span class="o">=</span> <span class="dl">"</span><span class="s2">http://www.w3.org/ns/solid/acp#AuthenticatedIssuer</span><span class="dl">"</span>
 <span class="kd">function</span> <span class="nx">issuerMatches</span><span class="p">(</span><span class="nx">issuer</span><span class="p">,</span> <span class="nx">context</span><span class="p">)</span> <span class="p">{</span>
   <span class="k">if</span> <span class="p">(</span><span class="nx">issuer</span> <span class="o">===</span> <span class="nx">publicIssuer</span><span class="p">)</span>
       <span class="k">return</span> <span class="kc">true</span>


### PR DESCRIPTION
Addresses acceptance criterion 1 of #319.

---

In case we decide to stay with `http` for the vocabulary base URI, this change modifies pseudocode to fit.

In my opinion we should not merge this but use `https` instead everywhere in the spec.