### PR TITLE
Change meeting time to avoid clash with Solid CG weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All contributors to any Work Items must be members of the Solid CG. It’s easy 
 
 Anyone can join the [Authorization Panel chat](https://gitter.im/solid/authorization-panel).
 
-Online panel meetings occur weekly on Wednesday, 14:00 UTC at https://meet.jit.si/solid-authorization. Meetings are transcribed and [published](https://github.com/solid/authorization-panel/tree/main/meetings/).
+Online panel meetings occur weekly on Wednesday, 15:00 UTC at https://meet.jit.si/solid-authorization. Meetings are transcribed and [published](https://github.com/solid/authorization-panel/tree/main/meetings/).
 
 
 ## Code of Conduct


### PR DESCRIPTION
The Solid CG Weekly [will be happening at 14:00 UTC on Wednesdays](https://github.com/solid/specification/pull/458) which clashes with the current authz pannel meetings.

Pushing it by one hour would avoid the clash.