### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/proposals/acp-specification/index.html
+++ b/proposals/acp-specification/index.html
@@ -159,11 +159,8 @@
       <p>
         This document was published by the
         <a href="https://www.w3.org/community/solid/">Solid Community Group</a>
-        as an Editor&#39;s Draft. The sections that have been incorporated have
-        been reviewed following the
-        <a href="https://github.com/solid/process">Solid process</a>. However,
-        the information in this document is still subject to change. You are
-        invited to
+        as an Editor&#39;s Draft. The information in this document is still
+        subject to change. You are invited to
         <a href="https://github.com/solid/specification/issues">contribute</a>
         any feedback, comments, or questions you might have.
       </p>


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.